### PR TITLE
analyze multi logical operators in the condition, and support multiple input files or directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Logs
 
+## 0.0.2 - 2022.01.12
+The basic workflow of cyclomatic complexity analysis on Python files
+### Added
+- Add the process based on tree-sitter
+- support multiple paths of files or directories via command as arguments
+### Changed
+- `paths` would be the argument via command instead of options
+
 ## 0.0.1 - 2022.01.11
 The backbone of analyze command with mock data
 ### Added

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -4,4 +4,4 @@ Janus is an analyzer of code cyclomatic complexity
 """
 
 
-VERSION = '0.0.1'
+VERSION = '0.0.2'

--- a/janus/app.py
+++ b/janus/app.py
@@ -10,14 +10,13 @@ PY_LANGUAGE = Language('build-tree-sitter/my-languages.so', 'python')
 
 class Janus(object):
 
-    DECISION_TYPE = ['if_statement',
-                     'elif_clause',
-                     'for_statement',
-                     'while_statement',
-                     'except_clause',
-                     'with_statement',
-                     'assert_statement',
-                     'list_comprehension']
+    # refer to the value in https://github.com/tree-sitter/tree-sitter-python/blob/master/src/grammar.json
+    DECISION_TYPES = [
+        'if', 'elif', 'assert',  # condition
+        'for', 'while',          # loop
+        'except', 'with',        # try / except
+        'and', 'or'              # logical operator
+    ]
 
     def __init__(self):
         self.parser = Parser()
@@ -26,18 +25,17 @@ class Janus(object):
     def process(self, f_path):  # NOQA
         with open(f_path, mode='rb') as f:
             tree = self.parser.parse(f.read())
-        complexity = self._search_statement(tree.root_node)
+        complexity = self._search_decisions(tree.root_node)
         return {'data': [{'file_path': f_path,
                           'cyclomatic_complexity': complexity}]}
 
-    def _search_statement(self, node):
+    def _search_decisions(self, node):
         counter = 0
         queue = [node]
         while queue:
             _node = queue.pop(0)
-            if _node.type in self.DECISION_TYPE:
+            if _node.type in self.DECISION_TYPES:
                 counter += 1
-            for _child_node in _node.children:
-                queue.append(_child_node)
+            queue.extend(_node.children)
 
         return counter + 1  # V(G) = P + 1

--- a/janus/cli.py
+++ b/janus/cli.py
@@ -6,14 +6,14 @@ from janus.app import Janus
 
 
 @click.command()
-@click.option('-f', '--file', required=True, help='source code file')
-def main(file):
+@click.argument('paths', nargs=-1, type=click.Path(exists=True))
+def main(paths):
     """
     Args:
-        file (str): the path of a file
+        paths (tuple): the paths of files or directories
     """
-    engine = Janus()
-    res = engine.process(file)
+    engine = Janus(paths)
+    res = engine.process()
     click.echo(json.dumps(res))
 
 


### PR DESCRIPTION
# Merge Request Type
* [ ] Bug fix
* [ ] Improvement
* [x] Feature Implementation
* [ ] Upgrade Dependencies

# Overall Description
* support Python's logical operators `and` and `or` when analyzing
```
"""
if isinstance(variable, int) or isinstance(variable, float):
    print('numeric')
else:
    print('non-numeric')
"""

it is equal to
"""
if isinstance(variable, int):
    print('numeric')
elif isinstance(variable, float):
    print('numeric')
else:
    print('non-numeric')
"""

so that the amount of decision point is 2, not 1
```
* support multiple paths of directories or files as arguments
